### PR TITLE
 Remove "exports" keywords from all JS modules

### DIFF
--- a/src/ext/jquery.coffee
+++ b/src/ext/jquery.coffee
@@ -4,16 +4,15 @@
 define (require) ->
   utils = require 'lib/utils'
 
-  exports =
-    setupError: (context) ->
-      $(document).ajaxError (event, jqXHR, options, error) ->
-        {status} = jqXHR
-        if status is 401
-          session = utils.parseJSON jqXHR.responseText
-          # `session` will be an object or false.
-          if session.CODE is 'SESSION_EXPIRED'
-            # Since the session is now expired reloading a page will trigger an
-            # auth check and bounce the user to the login page. Because of that
-            # after they successfully log back in they should be redirected back
-            # here.
-            (context or window).location.reload()
+  setupError: (context) ->
+    $(document).ajaxError (event, jqXHR, options, error) ->
+      {status} = jqXHR
+      if status is 401
+        session = utils.parseJSON jqXHR.responseText
+        # `session` will be an object or false.
+        if session.CODE is 'SESSION_EXPIRED'
+          # Since the session is now expired reloading a page will trigger an
+          # auth check and bounce the user to the login page. Because of that
+          # after they successfully log back in they should be redirected back
+          # here.
+          (context or window).location.reload()

--- a/src/lib/utils.coffee
+++ b/src/lib/utils.coffee
@@ -4,7 +4,7 @@
 
 # See [Chaplin utils](https://github.com/chaplinjs/chaplin-boilerplate/blob/master/coffee/lib/utils.coffee)
 # for an example.
-define (require, exports) ->
+define (require) ->
   Backbone = require 'backbone'
   Chaplin = require 'chaplin'
 
@@ -45,4 +45,4 @@ define (require, exports) ->
 
     result
 
-  exports = utils
+  utils

--- a/src/mixins/advice.coffee
+++ b/src/mixins/advice.coffee
@@ -1,7 +1,7 @@
 # Helper mixin to include AOP capabilities via `flight`.
-define (require, exports) ->
+define (require) ->
   advice = require 'flight/advice'
 
-  exports = ->
+  ->
     advice.withAdvice.call this unless @before
     this

--- a/src/mixins/bad-model.coffee
+++ b/src/mixins/bad-model.coffee
@@ -6,7 +6,7 @@
 # Specify a `route` key in `opts` to declare the route to redirect to
 # and specify a `message` to be passed with the event. If it's a function,
 # the first argument will be the model.
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
   utils = require '../lib/utils'
   advice = require 'flight/advice'
@@ -15,7 +15,7 @@ define (require, exports) ->
     classes: 'alert-danger'
     reqTimeout: 10000
 
-  exports = (opts={}) ->
+  (opts={}) ->
     # 'Extend' the `listen` hash, even if it's not present, without
     # having this handler overridden if the hash is declared later.
     @before 'delegateListeners', ->

--- a/src/mixins/collection-pagination.coffee
+++ b/src/mixins/collection-pagination.coffee
@@ -3,12 +3,12 @@
 #
 # It requires the view collection to have `paginationStats`
 # mixed in.
-define (require, exports) ->
+define (require) ->
   getTemplateData = ->
     @stats.num_items = @collection.pageString @stats
     @stats
 
-  exports = ->
+  ->
     @tagName = 'span'
     @className = "collection-pagination #{@className or ''}"
 

--- a/src/mixins/delayed-save.coffee
+++ b/src/mixins/delayed-save.coffee
@@ -1,4 +1,4 @@
-define (require, exports) ->
+define (require) ->
   successHandler = (opts) ->
     @publishEvent 'notify', opts.saveMessage,
       model: opts.model
@@ -12,6 +12,6 @@ define (require, exports) ->
         opts.$field.attr 'href', opts.href if opts.href
         @makeEditable opts
 
-  exports = ->
+  ->
     @delayedSave = successHandler
     this

--- a/src/mixins/editable.coffee
+++ b/src/mixins/editable.coffee
@@ -1,4 +1,4 @@
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
 
   DEFAULTS =
@@ -124,7 +124,7 @@ define (require, exports) ->
       opts.model ||= @model
       @makeEditable opts
 
-  exports = ->
+  ->
     @setupEditable = setupEditable
     @makeEditable = makeEditable
     this

--- a/src/mixins/email-validation.coffee
+++ b/src/mixins/email-validation.coffee
@@ -1,4 +1,4 @@
-define (require, exports) ->
+define (require) ->
     # Should match what we use in the backend
     # from this stackoverflow http://stackoverflow.com/questions/46155/
   regex = /// ^
@@ -9,7 +9,7 @@ define (require, exports) ->
     (([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))
     $ ///
 
-  exports = ->
+  ->
     @validateEmail = (email) ->
       # False for valid emails to work with validate-attrs mixin.
       !regex.test email

--- a/src/mixins/error-toggle-view.coffee
+++ b/src/mixins/error-toggle-view.coffee
@@ -3,9 +3,9 @@
 # and `fallbackSelector` that `Chaplin.CollectionView` provides.
 #
 # Works with the event emitted by the `service-unavailable` mixin.
-define (require, exports) ->
+define (require) ->
 
-  exports = ->
+  ->
     # 'Extend' the `listen` hash, even if it's not present, without
     # having this handler overridden if the hash is declared later.
     @before 'delegateListeners', ->

--- a/src/mixins/form-errors.coffee
+++ b/src/mixins/form-errors.coffee
@@ -12,7 +12,7 @@
 # specified via the `opts` hash with `inputAttr`.
 #
 # `id` and `class` attributes will use the appropriate selectors.
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
 
   # Map of the different methods for each attribute type.
@@ -60,7 +60,7 @@ define (require, exports) ->
       , this
 
   # For the time being, the mixin supports only a single form per (sub)?view.
-  exports = (opts = {}) ->
+  (opts = {}) ->
     # Message to display for general/parse errors.
     genericErrMsg =
       opts.genericErrMsg or 'There was a problem. Please try again.'

--- a/src/mixins/notification.coffee
+++ b/src/mixins/notification.coffee
@@ -29,7 +29,7 @@
 # Fade speed, timeout length, undo selector, stickiness, whether navigate
 # dismisses, link, click handler, and classes can be configured via the `opts`
 # hash this mixin is called with.
-define (require, exports) ->
+define (require) ->
   advice = require 'flight/advice'
 
   # Configurables
@@ -119,7 +119,7 @@ define (require, exports) ->
     classes = opts.classes or 'alert-success'
     @$el.addClass classes
 
-  exports = (opts={}) ->
+  (opts={}) ->
     # Retrieve options.
     undoSelector = opts.undoSelector or '.undo'
     fadeSpeed =

--- a/src/mixins/pagination-stats.coffee
+++ b/src/mixins/pagination-stats.coffee
@@ -1,4 +1,4 @@
-define (require, exports) ->
+define (require) ->
   advice = require 'flight/advice'
 
   # This method returns an object with properties about the page and
@@ -45,7 +45,7 @@ define (require, exports) ->
   pageString = (stats) ->
     "#{stats.start}-#{stats.end} of #{stats.total}"
 
-  exports = ->
+  ->
     @before 'initialize', ->
       @on 'remove', ->
         # Keep pagination views in sync on archive/delete.

--- a/src/mixins/parse-response.coffee
+++ b/src/mixins/parse-response.coffee
@@ -4,7 +4,7 @@
 # The collection will pull and store `count` from the response onto
 # the collection. It will return the models namespaced under
 # the collection's `syncKey` property.
-define (require, exports) ->
+define (require) ->
   # Handle API that returns payload in nested array with count.
   # **e.g.** `{"#{COUNT_PROP}": 1, "#{ROUTE_PROP}": [{...}]}`
   parse = (resp) ->
@@ -15,6 +15,6 @@ define (require, exports) ->
     else
       resp
 
-  exports = (opts={}) ->
+  (opts={}) ->
     @parse = parse
     this

--- a/src/mixins/reuse-view.coffee
+++ b/src/mixins/reuse-view.coffee
@@ -1,4 +1,4 @@
-define (require, exports) ->
+define (require) ->
   # For use on paginated collection views so we don't
   # have to recreate a new view for each page.
   # You can specify an optional `viewName` on the collection
@@ -14,6 +14,6 @@ define (require, exports) ->
     opts.collection = collection
     @reuse name, View, opts
 
-  exports = ->
+  ->
     @reuseView = reuseView
     this

--- a/src/mixins/safe-ajax-callback.coffee
+++ b/src/mixins/safe-ajax-callback.coffee
@@ -5,7 +5,7 @@
 # server methods (such as `fetch` and `save`) use. This makes it
 # incompatible with the related promise callbacks (`done`, `fail`, `always`)
 # which don't provide as nice of a hook with AOP.
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
   advice = require 'flight/advice'
 
@@ -19,6 +19,6 @@ define (require, exports) ->
           callback.apply ctx, arguments unless @disposed
     , this
 
-  exports = ->
+  ->
     @before 'sync', safeAjaxCallback
     this

--- a/src/mixins/scopeable.coffee
+++ b/src/mixins/scopeable.coffee
@@ -12,7 +12,7 @@
 #
 # Private methods need to use `call` so that the instance is used over the
 # constructor or global object.
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
   advice = require 'flight/advice'
   utils = require '../lib/utils'
@@ -62,7 +62,7 @@ define (require, exports) ->
     else
       utils.reverse @syncKey, null, params
 
-  exports = ->
+  ->
     @before 'sync', (method, collection, opts) ->
       if method is 'read'
         # Add `params` to the collection.

--- a/src/mixins/service-unavailable.coffee
+++ b/src/mixins/service-unavailable.coffee
@@ -4,7 +4,7 @@
 # as well.
 #
 # The `I18n` library is invoked if it exists, otherwise it uses a default.
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
   utils = require 'lib/utils'
 
@@ -43,7 +43,7 @@ define (require, exports) ->
           classes: 'alert-danger'
           reqTimeout: 10000
 
-  exports = ->
+  ->
     @before 'sync', serviceErrorCallback
     @before 'sync', serviceUnavailableCallback
 

--- a/src/mixins/string-template.coffee
+++ b/src/mixins/string-template.coffee
@@ -6,7 +6,7 @@
 #
 # You can override the template path by passing in `templatePath`
 # in the options.
-define (require, exports) ->
+define (require) ->
   templatePath = ''
 
   # Precompiled templates function initializer.
@@ -20,7 +20,7 @@ define (require, exports) ->
         errStr = "The template file #{templatePath}/#{template} doesn't exist."
         throw new Error errStr
 
-  exports = (opts={}) ->
+  (opts={}) ->
     # Reset between multiple calls.
     templatePath = opts.templatePath or 'views/templates'
 

--- a/src/mixins/sync-fetch.coffee
+++ b/src/mixins/sync-fetch.coffee
@@ -3,7 +3,7 @@
 #
 # It uses `flight/advice` for AOP to start the machine
 # before `fetch()`.
-define (require, exports) ->
+define (require) ->
   advice = require 'flight/advice'
 
   syncFetch = ->
@@ -12,6 +12,6 @@ define (require, exports) ->
       @beginSync()
       @on 'sync', @finishSync, this
 
-  exports = ->
+  ->
     @before 'fetch', syncFetch
     this

--- a/src/mixins/validate-attrs.coffee
+++ b/src/mixins/validate-attrs.coffee
@@ -4,14 +4,14 @@
 #
 # The specified function should return a truthy value only
 # if there is a problem (per Backbone conventions).
-define (require, exports) ->
+define (require) ->
   _ = require 'underscore'
 
   # Default validation criterion
   blank = (text) ->
     text.length is 0
 
-  exports = (opts) ->
+  (opts) ->
     # Map of attributes to validation method.
     {methods} = opts
     # Inlined to bind methods to the host object.

--- a/test/helpers/editable-view.coffee
+++ b/test/helpers/editable-view.coffee
@@ -1,9 +1,9 @@
-define (require, exports) ->
+define (require) ->
   Chaplin = require 'chaplin'
   editable = require 'mixins/editable'
   delayedSave = require 'mixins/delayed-save'
 
-  exports = class FakeView extends Chaplin.View
+  class FakeView extends Chaplin.View
     mixin.call @prototype for mixin in [editable, delayedSave]
     autoRender: yes
     getTemplateFunction: ->

--- a/test/helpers/setup-editable.coffee
+++ b/test/helpers/setup-editable.coffee
@@ -1,17 +1,16 @@
-define (require, exports) ->
-  exports =
-    before: ->
-      @field ||= '.name-field'
-      @click ||= '.edit-name'
-      @view.$(@click).click()
-      @value = 'Peter Bishop' if @value is undefined
-      @view.$(@field).text @value
-      event = if @event is undefined then @enter else @event
-      @view.$(@field).trigger event
+define (require) ->
+  before: ->
+    @field ||= '.name-field'
+    @click ||= '.edit-name'
+    @view.$(@click).click()
+    @value = 'Peter Bishop' if @value is undefined
+    @view.$(@field).text @value
+    event = if @event is undefined then @enter else @event
+    @view.$(@field).trigger event
 
-    after: ->
-      # FIXME: since error state is tracked globally it has to be reset after
-      # each test. it should not be tracked globally
-      @view.$(@field).text('Peter Bishop').trigger @enter
-      delete @click
-      delete @field
+  after: ->
+    # FIXME: since error state is tracked globally it has to be reset after
+    # each test. it should not be tracked globally
+    @view.$(@field).text('Peter Bishop').trigger @enter
+    delete @click
+    delete @field

--- a/test/helpers/validate-model.coffee
+++ b/test/helpers/validate-model.coffee
@@ -1,7 +1,7 @@
-define (require, exports) ->
+define (require) ->
   Chaplin = require 'chaplin'
 
-  exports = class FakeModel extends Chaplin.Model
+  class FakeModel extends Chaplin.Model
     # Default validation criterion for editable field.
     validate: (attrs, opts) ->
       for attr, val of attrs


### PR DESCRIPTION
Since we are doing this now for every other file, just to make the update for all modules at once