### PR TITLE
Handlebars updated to v4.0.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "backbone": "1.1.1",
     "chaplin": "1.0.0",
     "flight": "1.1.4",
-    "handlebars": "1.3.0",
+    "handlebars": "4.0.5",
     "jquery": "2.1.0",
     "lodash": "2.4.1",
     "moment": "2.10.3",


### PR DESCRIPTION
Reason: the in-place (dynamic) partial templates is a very useful feature to have in the coding routine. This update is too avoid version conflicts in projects that depend on gringotts.