### PR TITLE
Introduce notifications observer collection

### DIFF
--- a/src/errors.coffee
+++ b/src/errors.coffee
@@ -60,4 +60,4 @@ define (require) ->
       if status is 401 then _handle401 context, $xhr
       else if status is 403 and not handled then _handle403 context, $xhr
       # Don't trigger for canceled requests.
-      else if status isnt 0 and not handled then _handle context, $xhr
+      else if status not in [0, 201] and not handled then _handle context, $xhr

--- a/src/models/base/collection.coffee
+++ b/src/models/base/collection.coffee
@@ -1,0 +1,41 @@
+define (require) ->
+  Chaplin = require 'chaplin'
+  Model = require './model'
+  advice = require '../../mixins/advice'
+  paginationStats = require '../../mixins/pagination-stats'
+  parseResponse = require '../../mixins/parse-response'
+  safeAjaxCallback = require '../../mixins/safe-ajax-callback'
+  serviceUnavailable = require '../../mixins/service-unavailable'
+  scopeable = require '../../mixins/scopeable'
+  syncFetch = require '../../mixins/sync-fetch'
+
+  # Generic base class for collections. Includes useful mixins by default.
+  class Collection extends Chaplin.Collection
+    _.extend @prototype, Chaplin.SyncMachine
+    # Additonal logic in `sync` and `fetch` should be done with AOP.
+    _.each [
+      advice # Advice needs to come first.
+      paginationStats
+      parseResponse
+      safeAjaxCallback
+      serviceUnavailable
+      scopeable
+      syncFetch
+    ], (mixin) ->
+      mixin.call @prototype
+    , this
+
+    DEFAULTS:
+      page: 1
+      per_page: 30
+      order: 'asc'
+
+    model: Model
+
+    @::before 'initialize', ->
+      # Without this collections keep growing and it causes problems with new
+      # notifications being inserted after old ones are disposed.
+      @on 'dispose', (model) -> @remove model
+
+    pageString: (stats) ->
+      I18n?.t 'items.total', stats

--- a/src/models/base/model.coffee
+++ b/src/models/base/model.coffee
@@ -1,0 +1,18 @@
+define (require) ->
+  Chaplin = require 'chaplin'
+  advice = require '../../mixins/advice'
+  safeAjaxCallback = require '../../mixins/safe-ajax-callback'
+  serviceUnavailable = require '../../mixins/service-unavailable'
+  syncFetch = require '../../mixins/sync-fetch'
+
+  # Generic base class for models. Includes useful mixins by default.
+  class Model extends Chaplin.Model
+    _.extend @prototype, Chaplin.SyncMachine
+    _.each [
+        advice
+        safeAjaxCallback
+        serviceUnavailable
+        syncFetch
+    ], (mixin) ->
+      mixin.call @prototype
+    , this

--- a/src/models/notifications.coffee
+++ b/src/models/notifications.coffee
@@ -1,0 +1,11 @@
+define (require) ->
+  Collection = require './base/collection'
+
+  # An observer class for notifications. It makes sure that same messages
+  # are not duplicated in the collection.
+  class Notifications extends Collection
+    initialize: ->
+      super
+      @subscribeEvent 'notify', (message, opts) ->
+        @remove @where {message}
+        @add {message, opts}

--- a/test/models/notifications-collection-test.coffee
+++ b/test/models/notifications-collection-test.coffee
@@ -1,0 +1,38 @@
+define (require) ->
+  Notifications = require 'models/notifications'
+
+  describe 'Notifications', ->
+    beforeEach ->
+      @collection = new Notifications()
+
+    afterEach ->
+      @collection.dispose()
+
+    context 'on notifying a message', ->
+      beforeEach ->
+        @message1 = 'A message for you, Rudy!'
+        @collection.publishEvent 'notify', @message1
+      afterEach -> delete @message1
+
+      it 'should add a message', ->
+        expect(@collection).to.have.lengthOf 1
+        expect(@collection.first().get('message')).to.equal @message1
+
+      context 'on notifying another message', ->
+        beforeEach ->
+          @message2 = 'Something good just happened.'
+          @collection.publishEvent 'notify', @message2
+        afterEach -> delete @message2
+
+        it 'should add a message', ->
+          expect(@collection).to.have.lengthOf 2
+          expect(@collection.at(1).get('message')).to.equal @message2
+
+        context 'on notifying first message', ->
+          beforeEach ->
+            @collection.publishEvent 'notify', @message1
+
+          it 'should remove existing message and re-add it again', ->
+            expect(@collection).to.have.lengthOf 2
+            expect(@collection.first().get('message')).to.equal @message2
+            expect(@collection.at(1).get('message')).to.equal @message1


### PR DESCRIPTION
Adding rules to remove existing messages with same text
Base classses for Model and Collection introduced
The essential mixins are included in base model classes
Skip status 201 in generic errors handler
Unit tests added.

This partially resolves #12