### PR TITLE
Extend FilterInputView features

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -258,7 +258,6 @@ module.exports = (grunt) ->
       buildPath = grunt.option 'target'
       if buildPath
         grunt.log.writeln "Building gringotts into #{buildPath}..."
-        grunt.option 'env', 'prod'
         grunt.task.run [
           'build'
           'connect'

--- a/src/lib/utils.coffee
+++ b/src/lib/utils.coffee
@@ -152,3 +152,10 @@ define (require) ->
         , url
       else if _.isString params
         @excludeUrlParam url, params
+
+    ###*
+    * If obj is a single element array, the element is returned. Otherwise the
+    * obj itself will be returned.
+    ###
+    compress: (obj) ->
+      if _.isArray(obj) and obj.length is 1 then obj[0] else obj

--- a/src/mixins/models/filter-grouped.coffee
+++ b/src/mixins/models/filter-grouped.coffee
@@ -1,0 +1,51 @@
+define (require) ->
+  helper = require '../../lib/mixin-helper'
+
+  isPerhapsSynced = (collection) ->
+    if _.isFunction collection?.isSynced then collection.isSynced() else yes
+
+  ###*
+   * Helps synchronize sync state of a collection and it's children collections.
+   * This mixin works the best when applied to Collections that serve as a
+   * filter groups source of the FilterInputView control.
+  ###
+  (superclass) -> class FilterGrouped extends superclass
+    helper.setTypeName @prototype, 'FilterGrouped'
+
+    initialize: ->
+      helper.assertCollection this
+      super
+      @addSyncDeepListener this
+      @on 'add', (model) -> @addSyncDeepListener model.get 'children'
+      @on 'remove', (model) -> @removeSyncDeepListener model.get 'children'
+
+    reset: ->
+      super
+      @each (model) =>
+        @addSyncDeepListener model.get 'children'
+
+    fetchChildren: ->
+      $.when.apply this, @reduce (promises, model) ->
+        if _.result (children = model.get 'children'), 'url'
+          promises.push children.fetch()
+        promises
+      , []
+
+    isSyncedDeep: ->
+      isPerhapsSynced(this) and @reduce (synced, model) ->
+        synced and isPerhapsSynced model.get 'children'
+      , true
+
+    addSyncDeepListener: (collection) ->
+      collection?.on 'sync', @triggerSyncDeep
+
+    removeSyncDeepListener: (collection) ->
+      collection?.off 'sync', @triggerSyncDeep
+
+    triggerSyncDeep: =>
+      @trigger 'syncDeep', this if @isSyncedDeep()
+
+    dispose: ->
+      @each (model) ->
+        model.get('children')?.dispose()
+      super

--- a/src/mixins/models/queryable.coffee
+++ b/src/mixins/models/queryable.coffee
@@ -141,8 +141,8 @@ define (require) ->
     ###
     stripEmptyOrDefault: (query, opts={}) ->
       query = _.omit query, (value, key) =>
-        value is undefined or
-          (_.isEqual(@DEFAULTS[key], value) and !opts.inclDefaults)
+        value is undefined or (not opts.inclDefaults and \
+          _.isEqual utils.compress(@DEFAULTS[key]), utils.compress value)
 
     ###*
      * Saves all alien values (without prefixes) into a separete hash

--- a/src/mixins/views/filtering.coffee
+++ b/src/mixins/views/filtering.coffee
@@ -1,0 +1,66 @@
+define (require) ->
+  helper = require '../../lib/mixin-helper'
+  FilterSelection = require '../../models/filter-selection'
+  FilterInputView = require '../../views/filter-input-view'
+  Routing = require './routing'
+
+  isPerhapsSyncedDeep = (collection) ->
+    if _.isFunction collection.isSyncedDeep
+    then collection.isSyncedDeep() else yes
+
+  ###*
+   * Helps initialize and sync the filter selection state of the FilterInputView
+   * control and the underlying CollectionView's queryable collection.
+  ###
+  (superclass) -> class Filtering extends Routing superclass
+    helper.setTypeName @prototype, 'Filtering'
+    optionNames: @::optionNames.concat ['filterGroups']
+    filterSelection: FilterSelection
+
+    filteringIsActive: ->
+      @filterSelection and @filterGroups
+
+    initialize: ->
+      helper.assertViewOrCollectionView this
+      super
+      @filterSelection = new @filterSelection()
+      @addFilterSelectionListeners()
+
+    render: ->
+      super
+      if @filteringIsActive()
+        @subview 'filtering-control', new FilterInputView
+          el: @$ '.filtering-control[data-filter-input]'
+          collection: @filterSelection
+          groupSource: @filterGroups
+      @updateFilterSelection()
+
+    onBrowserQueryChange: ->
+      super
+      @updateFilterSelection()
+
+    updateFilterSelection: ->
+      return unless @filteringIsActive()
+      if isPerhapsSyncedDeep @filterGroups
+        @resetFilterSelection @getBrowserQuery()
+      else
+        @listenTo @filterGroups, 'syncDeep', ->
+          @resetFilterSelection @getBrowserQuery()
+
+    resetFilterSelection: (obj) ->
+      @removeFilterSelectionListeners()
+      @filterSelection.fromObject obj, @filterGroups
+      @addFilterSelectionListeners()
+
+    addFilterSelectionListeners: ->
+      @listenTo @filterSelection, 'update', @onFilterSelectionUpdate
+      @listenTo @filterSelection, 'reset', @onFilterSelectionUpdate
+
+    removeFilterSelectionListeners: ->
+      @stopListening @filterSelection, 'update', @onFilterSelectionUpdate
+      @stopListening @filterSelection, 'reset', @onFilterSelectionUpdate
+
+    onFilterSelectionUpdate: ->
+      query = _.defaults @filterSelection.toObject(),
+        _.zipObject @filterGroups.pluck 'id'
+      @setBrowserQuery _.extend query, page: 1

--- a/src/templates/filter-input/item.hbs
+++ b/src/templates/filter-input/item.hbs
@@ -1,4 +1,6 @@
 <span class="selected-item">
   <span class="item-group">{{groupName}}</span>&nbsp;<span class="item-name">{{name}}</span>
-  <button type="button" class="close remove-button">&times;</button>
+  <button type="button" class="btn btn-link remove-button">
+    {{icon 'misc-x'}}
+  </button>
 </span>

--- a/src/templates/filter-input/list-item.hbs
+++ b/src/templates/filter-input/list-item.hbs
@@ -1,6 +1,9 @@
 <li>
   <a href="#">
-    <div class="item-name">{{name}}</div>
+    <div>
+      <span class="item-name">{{name}}</span>
+      <span class="item-note"></span>
+    </div>
     <div class="sub-text item-description">{{description}}</div>
   </a>
 </li>

--- a/src/templates/filter-input/view.hbs
+++ b/src/templates/filter-input/view.hbs
@@ -1,20 +1,29 @@
-<span class="list-item loading" style="display: none">{{loadingText}}</span>
-<span class="list-item service-error">{{errorText}}</span>
-<span class="dropdown-control">
-  <span class="selected-group"></span>
-  <span class="dropdown">
-    <input placeholder="{{placeholder}}" data-toggle="dropdown"
-        {{#if disabled}}disabled{{/if}}  />
-    <ul class="dropdown-menu dropdown-groups">
-      <li class="loading" style="display: none"><label>{{loadingText}}</label></li>
-      <li class="empty"><label>{{emptyText}}</label></li>
-      <li class="service-error"><label>{{errorText}}</label></li>
-    </ul>
-    <ul class="dropdown-menu dropdown-items hidden">
-      <li class="loading" style="display: none"><label>{{loadingText}}</label></li>
-      <li class="empty"><label>{{emptyText}}</label></li>
-      <li class="service-error"><label>{{errorText}}</label></li>
-    </ul>
+{{icon 'misc-search'}}
+<div class="filter-items-container">
+  <span class="list-item loading" style="display: none">{{loadingText}}</span>
+  <span class="list-item service-error">{{errorText}}</span>
+  <span class="dropdown-control">
+    <span class="selected-group"></span>
+    <span class="dropdown">
+      <input placeholder="{{placeholder}}" data-toggle="dropdown"
+          {{#if disabled}}disabled{{/if}}  />
+      <ul class="dropdown-menu dropdown-groups">
+        <li class="no-hover loading" style="display: none">
+          <label>{{loadingText}}</label>
+        </li>
+        <li class="no-hover empty"><label>{{emptyText}}</label></li>
+        <li class="no-hover service-error"><label>{{errorText}}</label></li>
+      </ul>
+      <ul class="dropdown-menu dropdown-items hidden">
+        <li class="no-hover loading" style="display: none">
+          <label>{{loadingText}}</label>
+        </li>
+        <li class="no-hover empty"><label>{{emptyText}}</label></li>
+        <li class="no-hover service-error"><label>{{errorText}}</label></li>
+      </ul>
+    </span>
   </span>
-</span>
-<button type="button" class="close remove-all-button">&times;</button>
+</div>
+<button type="button" class="btn btn-link remove-all-button">
+  {{icon 'misc-x'}}
+</button>

--- a/test/lib/utils-test.coffee
+++ b/test/lib/utils-test.coffee
@@ -276,3 +276,16 @@ define (require) ->
 
         it 'should return proper url', ->
           expect(result).to.equal 'some/url?e=f'
+
+    context 'compress', ->
+      context 'passing undefined', ->
+        it 'should return undefined', ->
+          expect(utils.compress undefined).to.be.undefined
+
+      context 'passing single element array', ->
+        it 'should return the element', ->
+          expect(utils.compress [5]).to.equal 5
+
+      context 'passing multiple elements array', ->
+        it 'should return the array', ->
+          expect(utils.compress [6, 7]).to.eql [6, 7]

--- a/test/mixins/models/filter-grouped-test.coffee
+++ b/test/mixins/models/filter-grouped-test.coffee
@@ -1,0 +1,95 @@
+define (require) ->
+  Chaplin = require 'chaplin'
+  ActiveSyncMachine = require 'mixins/models/active-sync-machine'
+  FilterGrouped = require 'mixins/models/filter-grouped'
+
+  class ChildrenMock extends ActiveSyncMachine Chaplin.Collection
+    url: '/test'
+    fetch: ->
+      @beginSync()
+      @finishSync()
+      @trigger 'sync'
+      $.Deferred().resolve()
+
+  class CollectionMock extends FilterGrouped ActiveSyncMachine \
+      Chaplin.Collection
+    constructor: ->
+      super [
+        new Chaplin.Model()
+        new Chaplin.Model children: new ChildrenMock()
+        new Chaplin.Model children: new ChildrenMock()
+      ]
+
+  describe 'FilterGrouped', ->
+    sandbox = null
+    collection = null
+
+    beforeEach ->
+      sandbox = sinon.sandbox.create()
+      collection = new CollectionMock()
+      sandbox.spy collection, 'trigger'
+
+    afterEach ->
+      sandbox.restore()
+      collection.dispose()
+
+    it 'should not trigger events', ->
+      expect(collection.trigger).to.have.not.been.called
+
+    expectStateOnFetch = (continueHandler) ->
+      it 'should not be synced deep', ->
+        expect(collection.isSyncedDeep()).to.be.false
+
+      context 'on fetch', ->
+        beforeEach ->
+          collection.beginSync()
+          collection.finishSync()
+          collection.fetchChildren()
+
+        it 'should be synced deep', ->
+          expect(collection.isSyncedDeep()).to.be.true
+
+        it 'should trigger syncDeep event', ->
+          expect(collection.trigger).to.have.been
+            .calledWith 'syncDeep', collection
+
+        continueHandler() if continueHandler
+
+    expectStateOnFetch ->
+      context 'and adding an item', ->
+        beforeEach ->
+          collection.add \
+            new Chaplin.Model children: new ChildrenMock()
+
+        expectStateOnFetch()
+
+      context 'and removing an item', ->
+        beforeEach ->
+          collection.trigger.reset()
+          model = collection.pop()
+          model.get('children').fetch()
+
+        it 'should not trigger syncDeep event', ->
+          expect(collection.trigger).to.have.not.been.calledWith 'syncDeep'
+
+      context 'and reset', ->
+        beforeEach ->
+          collection.reset [
+            new Chaplin.Model children: new ChildrenMock()
+            new Chaplin.Model children: new ChildrenMock()
+            new Chaplin.Model()
+            new Chaplin.Model()
+          ]
+
+        expectStateOnFetch()
+
+    context 'on dispose', ->
+      children = null
+
+      beforeEach ->
+        children = _.compact collection.pluck 'children'
+        sandbox.restore()
+        collection.dispose()
+
+      it 'should have all item children disposed', ->
+        children.forEach (c) -> expect(c.disposed).to.be.true

--- a/test/mixins/models/queryable-test.coffee
+++ b/test/mixins/models/queryable-test.coffee
@@ -86,7 +86,7 @@ define (require) ->
 
       beforeEach ->
         collection.ignoreKeys = ['coo']
-        difference = collection.setQuery foo: 1, boo: 'goo', coo: 'hoo'
+        difference = collection.setQuery foo: 1, boo: ['goo'], coo: 'hoo'
         collection.fetch()
         sandbox.server.respond()
 
@@ -104,7 +104,7 @@ define (require) ->
 
       context 'setting the same query again', ->
         beforeEach ->
-          difference = collection.setQuery boo: 'goo', foo: 1, coo: 'hoo'
+          difference = collection.setQuery boo: ['goo'], foo: 1, coo: 'hoo'
 
         it 'should return null difference for setQuery call', ->
           expect(difference).to.be.null

--- a/test/mixins/views/filtering-test.coffee
+++ b/test/mixins/views/filtering-test.coffee
@@ -1,0 +1,126 @@
+define (require) ->
+  Chaplin = require 'chaplin'
+  StringTemplatable = require 'mixins/views/string-templatable'
+  Filtering = require 'mixins/views/filtering'
+
+  class FilterSelectionMock extends Chaplin.Collection
+    fromObject: ->
+      @trigger 'update'
+      @trigger 'reset'
+    toObject: ->
+      x: 'z'
+
+  class ViewMock extends Filtering StringTemplatable Chaplin.View
+    autoRender: yes
+    template: 'filtering-test'
+    filterSelection: FilterSelectionMock
+    getBrowserQuery: ->
+    setBrowserQuery: ->
+
+  describe 'Filtering', ->
+    sandbox = null
+    view = null
+    filterGroups = null
+    browserQuery = null
+    withSyncDeep = null
+
+    beforeEach ->
+      sandbox = sinon.sandbox.create()
+      sandbox.spy FilterSelectionMock::, 'fromObject'
+      sandbox.spy FilterSelectionMock::, 'toObject'
+      filterGroups = new Chaplin.Collection [{id: 'a'}, {id: 'b'}]
+      if withSyncDeep
+        filterGroups.isSyncedDeep = -> false
+      sandbox.stub ViewMock::, 'getBrowserQuery', -> browserQuery or a: 'b'
+      sandbox.stub ViewMock::, 'setBrowserQuery'
+      view = new ViewMock {filterGroups}
+
+    afterEach ->
+      sandbox.restore()
+      view.dispose()
+      filterGroups.dispose()
+
+    it 'should initialize filter view', ->
+      filterView = view.subview 'filtering-control'
+      expect(filterView.collection).to.be.instanceOf FilterSelectionMock
+      expect(filterView.groupSource).to.equal filterGroups
+
+    it 'should render filter view', ->
+      expect(view.$ '.filter-input').to.exist
+
+    expectResetSelection = (query) ->
+      it 'should update filterSelection', ->
+        expect(view.filterSelection.fromObject).to.have.been.calledWith \
+          query?() or a: 'b', filterGroups
+
+      it 'should not set browser query', ->
+        expect(view.setBrowserQuery).to.have.not.been.called
+
+    context 'without filterGroups.isSyncedDeep', ->
+      expectResetSelection()
+
+    context 'with filterGroups.isSyncedDeep', ->
+      before ->
+        withSyncDeep = true
+
+      after ->
+        withSyncDeep = false
+
+      it 'should not update filterSelection', ->
+        expect(view.filterSelection.fromObject).to.have.not.been.called
+
+      context 'on syncDeep triggered', ->
+        beforeEach ->
+          filterGroups.trigger 'syncDeep'
+
+        expectResetSelection()
+
+    context 'on browser query change', ->
+      filterngIsntActive = null
+
+      before ->
+        browserQuery = c: 'd'
+
+      after ->
+        browserQuery = null
+
+      beforeEach ->
+        if filterngIsntActive
+          delete view.filterGroups
+          view.filterSelection.fromObject.reset()
+        view.onBrowserQueryChange()
+
+      expectResetSelection -> browserQuery
+
+      context 'when filtering is not active', ->
+        before ->
+          filterngIsntActive = true
+
+        after ->
+          filterngIsntActive = null
+
+        it 'should not update filterSelection', ->
+          expect(view.filterSelection.fromObject).to.have.not.been.called
+
+    context 'on filter selection', ->
+      event = null
+
+      beforeEach ->
+        view.filterSelection.trigger event
+
+      expectQuery = ->
+        it 'should set browser query', ->
+          expect(view.setBrowserQuery).to.have.been.calledWith \
+            x: 'z', a: undefined, b: undefined, page: 1
+
+      context 'update event', ->
+        before ->
+          event = 'update'
+
+        expectQuery()
+
+      context 'update event', ->
+        before ->
+          event = 'reset'
+
+        expectQuery()

--- a/test/templates/filtering-test.hbs
+++ b/test/templates/filtering-test.hbs
@@ -1,0 +1,1 @@
+<div data-filter-input class="filtering-control"  />

--- a/test/templates/foo/automatable-view.hbs
+++ b/test/templates/foo/automatable-view.hbs
@@ -1,1 +1,0 @@
-<span class="something"></span>


### PR DESCRIPTION
* Add few new mixins
  - FilterGrouped, helps maintaine deepSync state for filterGroups
  - Filtering, helps init FilterInputView and pass filter from/to Queryable collection
* Update FilterSelection base class, support of missing and leaf groups
* Update FilterInputView layout, icon, remove-all button, add new features:
  - Highlight of search text in every dropdown item
  - Support of singular filters (only one selected value allowed)
  - Support of leaf groups (no children, for example “Search” filter actions)