### PR TITLE
Add few improvements to FilterInputView

### DIFF
--- a/src/mixins/views/filtering.coffee
+++ b/src/mixins/views/filtering.coffee
@@ -49,7 +49,7 @@ define (require) ->
 
     resetFilterSelection: (obj) ->
       @removeFilterSelectionListeners()
-      @filterSelection.fromObject obj, @filterGroups
+      @filterSelection.fromObject obj, {@filterGroups}
       @addFilterSelectionListeners()
 
     addFilterSelectionListeners: ->
@@ -61,6 +61,6 @@ define (require) ->
       @stopListening @filterSelection, 'reset', @onFilterSelectionUpdate
 
     onFilterSelectionUpdate: ->
-      query = _.defaults @filterSelection.toObject(),
+      query = _.defaults @filterSelection.toObject({@filterGroups}),
         _.zipObject @filterGroups.pluck 'id'
       @setBrowserQuery _.extend query, page: 1

--- a/src/templates/filter-input/item.hbs
+++ b/src/templates/filter-input/item.hbs
@@ -1,6 +1,8 @@
 <span class="selected-item">
   <span class="item-group">{{groupName}}</span>&nbsp;<span class="item-name">{{name}}</span>
-  <button type="button" class="btn btn-link remove-button">
-    {{icon 'misc-x'}}
-  </button>
+  {{#unless required}}
+    <button type="button" class="btn btn-link remove-button">
+      {{icon 'misc-x'}}
+    </button>
+  {{/unless}}
 </span>

--- a/test/mixins/views/filtering-test.coffee
+++ b/test/mixins/views/filtering-test.coffee
@@ -51,7 +51,7 @@ define (require) ->
     expectResetSelection = (query) ->
       it 'should update filterSelection', ->
         expect(view.filterSelection.fromObject).to.have.been.calledWith \
-          query?() or a: 'b', filterGroups
+          query?() or a: 'b', {filterGroups}
 
       it 'should not set browser query', ->
         expect(view.setBrowserQuery).to.have.not.been.called

--- a/test/models/filter-selection-test.coffee
+++ b/test/models/filter-selection-test.coffee
@@ -16,12 +16,13 @@ define (require) ->
       name: '0-9'
       children: new Chaplin.Collection [
         new Chaplin.Model id: 'filter1'
-        new Chaplin.Model id: 'filter2'
+        new Chaplin.Model id: 'filterB'
         new Chaplin.Model id: 'filter3'
       ]
     new Chaplin.Model
       id: 'random'
       name: '$$$'
+      required: yes
       children: new Chaplin.Collection [
         new Chaplin.Model id: '###'
         new Chaplin.Model id: '&&&'
@@ -30,7 +31,7 @@ define (require) ->
 
   filtersObj =
     alphabet: ['filterA', 'filterB']
-    digits: ['filter1', 'filter2']
+    digits: ['filter1', 'filterB']
     missing: 'value'
     random: '###'
 
@@ -45,7 +46,7 @@ define (require) ->
 
     context 'fromObject', ->
       beforeEach ->
-        collection.fromObject filtersObj, filterGroups
+        collection.fromObject filtersObj, {filterGroups}
 
       it 'should exact number of filter items into selection', ->
         expect(collection.length).to.equal 5
@@ -56,9 +57,14 @@ define (require) ->
           id: 'filterA'
           groupId: 'alphabet'
           groupName: 'A-Z'
-        filter2 = collection.findWhere id: 'filter2'
-        expect(filter2.attributes).to.eql
-          id: 'filter2'
+        filterB_1 = collection.findWhere id: 'filterB', groupId: 'alphabet'
+        expect(filterB_1.attributes).to.eql
+          id: 'filterB'
+          groupId: 'alphabet'
+          groupName: 'A-Z'
+        filterB_2 = collection.findWhere id: 'filterB', groupId: 'digits'
+        expect(filterB_2.attributes).to.eql
+          id: 'filterB'
           groupId: 'digits'
           groupName: '0-9'
         filterVal = collection.findWhere id: 'value'
@@ -68,6 +74,7 @@ define (require) ->
           id: '###'
           groupId: 'random'
           groupName: '$$$'
+          required: yes
 
     context 'toObject', ->
       obj = null
@@ -86,11 +93,12 @@ define (require) ->
             id: 'filter1'
             groupId: 'digits'
           new Chaplin.Model
-            id: 'filter2'
+            id: 'filterB'
             groupId: 'digits'
           new Chaplin.Model
             id: '###'
             groupId: 'random'
+            required: yes
         ]
         obj = collection.toObject opts
         expectObj = _(filtersObj).omit('missing').value()


### PR DESCRIPTION
* Support of `required` items, they can’t be removed through UI actions
* Disable “Search” (leaf) item by default if there is no search query set
* Pass `filterGroups` to `FilterSelection.toObject`
  - This helps to build extended custom rules around filter serialization