### PR TITLE
Improve FilterInputView

### DIFF
--- a/src/templates/filter-input/list-item.hbs
+++ b/src/templates/filter-input/list-item.hbs
@@ -1,9 +1,6 @@
-<li class="filter-item">
-  <a href="#">
-    <div>
-      <span class="item-name">{{name}}</span>
-      <span class="item-note"></span>
-    </div>
+<a href="#">
+  <div class="item-name">{{name}}</div>
+  {{#if description}}
     <div class="sub-text item-description">{{description}}</div>
-  </a>
-</li>
+  {{/if}}
+</a>


### PR DESCRIPTION
* Groups with empty descriptions will get ones generated from children names
(even loaded asynchronously)
* Ability to search in filter group children
  - Group descriptions are dynamically updated to include matched names
* Search match only beginning of the word
  - Although numbers are given priority to match inside words as well
* Refactoring of highlighting code block, to be less jQuery oriented (more performance)
* Force filter on "Enter" for super quick typings