### PR TITLE
Various improvements

### DIFF
--- a/src/lib/view-helper.coffee
+++ b/src/lib/view-helper.coffee
@@ -49,6 +49,7 @@ define (require) ->
   # **e.g.** `ll, h:mm:ss a`
   handlebars.registerHelper 'dateFormat', (opts...) ->
     [time, format, inputFormat] = _.initial opts
+    return unless time
     hbsOpts = _.last opts
     moment(time, inputFormat or moment.ISO_8601).format(format)
 

--- a/src/mixins/views/paginating.coffee
+++ b/src/mixins/views/paginating.coffee
@@ -73,7 +73,6 @@ define (require) ->
         count: @collection.count
         page: page
         perPage: perPage
-
       if infinite
         info.pages = 1
         info.multiPaged = true
@@ -85,13 +84,15 @@ define (require) ->
         info.prev = if page > 1 then page - 1 else 0
         info.next = if page < info.pages then page + 1 else 0
         info.range = @getRangeString page, perPage, info
-
+      options = inclDefaults: no, inclIgnored: no, usePrefix: yes
       info.nextQuery =
-        if info.next then @routeQueryable.getQuery overrides: page: info.next
-        else @routeQueryable.getQuery()
+        if info.next
+        then @getBrowserQuery _.extend {}, options, overrides: page: info.next
+        else @getBrowserQuery options
       info.prevQuery =
-        if info.prev then @routeQueryable.getQuery overrides: page: info.prev
-        else @routeQueryable.getQuery()
+        if info.prev
+        then @getBrowserQuery _.extend {}, options, overrides: page: info.prev
+        else @getBrowserQuery options
 
       info.routeName = @routeName
       info.routeParams = @routeParams

--- a/src/mixins/views/routing.coffee
+++ b/src/mixins/views/routing.coffee
@@ -64,10 +64,11 @@ define (require) ->
      * Returns current query of the browser query relevant to the routeName.
      * @return {Object}
     ###
-    getBrowserQuery: ->
+    getBrowserQuery: (options) ->
+      options = _.defaults {}, options, inclDefaults: yes, usePrefix: no
       unless @routeQueryable
         throw new Error "Can't get query since @routeQueryable isn't set."
-      @routeQueryable.getQuery inclDefaults: yes, usePrefix: no
+      @routeQueryable.getQuery options
 
     ###*
      * Redirect to current route with new query params.

--- a/src/mixins/views/sorting.coffee
+++ b/src/mixins/views/sorting.coffee
@@ -64,8 +64,11 @@ define (require) ->
           order: order
           routeName: @routeName
           routeParams: @routeParams
-          nextQuery: @routeQueryable.getQuery overrides:
-            order: nextOrder, sort_by: column
+          nextQuery: @getBrowserQuery
+            inclDefaults: no
+            inclIgnored: no
+            usePrefix: yes
+            overrides: order: nextOrder, sort_by: column
         result
       , {}
 

--- a/test/lib/view-helper-test.coffee
+++ b/test/lib/view-helper-test.coffee
@@ -100,14 +100,19 @@ define (require) ->
         icon = handlebars.helpers.icon()
         expect(icon).to.be.undefined
 
-    it 'should format date correctly with default input format', ->
-      timeStamp = handlebars.helpers.dateFormat '1969-12-31', 'l', {}
-      expect(timeStamp).to.equal '12/31/1969'
+    context 'mail helper', ->
+      it 'should format date correctly with default input format', ->
+        timeStamp = handlebars.helpers.dateFormat '1969-12-31', 'l', {}
+        expect(timeStamp).to.equal '12/31/1969'
 
-    it 'should format date correctly with custom input format', ->
-      timeStamp = handlebars.helpers.dateFormat '26/11/1982', 'l',
-        'DD/MM/YYYY', {}
-      expect(timeStamp).to.equal '11/26/1982'
+      it 'should format date correctly with custom input format', ->
+        timeStamp = handlebars.helpers.dateFormat '26/11/1982', 'l',
+          'DD/MM/YYYY', {}
+        expect(timeStamp).to.equal '11/26/1982'
+
+      it 'should return nothing if input value is falsy', ->
+        timeStamp = handlebars.helpers.dateFormat null, 'l', {}
+        expect(timeStamp).to.be.undefined
 
     context 'mail helper', ->
       $el = null

--- a/test/mixins/models/queryable-test.coffee
+++ b/test/mixins/models/queryable-test.coffee
@@ -102,6 +102,14 @@ define (require) ->
         request = _.last sandbox.server.requests
         expect(request.url).to.not.contain 'coo=hoo'
 
+      it 'should return ignored keys in getQuery result', ->
+        query = collection.getQuery()
+        expect(query.coo).to.eq 'hoo'
+
+      it 'should ignore keys in getQuery result', ->
+        query = collection.getQuery inclIgnored: no
+        expect(query.coo).to.be.undefined
+
       context 'setting the same query again', ->
         beforeEach ->
           difference = collection.setQuery boo: ['goo'], foo: 1, coo: 'hoo'

--- a/test/mixins/views/paginating-test.coffee
+++ b/test/mixins/views/paginating-test.coffee
@@ -16,6 +16,7 @@ define (require) ->
     DEFAULTS: _.extend {}, @::DEFAULTS, per_page: 10
     urlRoot: '/test'
     syncKey: 'itemsList'
+    ignoreKeys: ['bad']
 
   class PaginatingViewMock extends StringTemplatable \
       Paginating Chaplin.CollectionView
@@ -37,7 +38,7 @@ define (require) ->
       collection = new PaginatedCollectionMock()
       collection.infinite = infinite
       view = new PaginatingViewMock {routeName: 'test', collection}
-      collection.fetchWithQuery {}
+      collection.fetchWithQuery {bad: 'something'}
       sandbox.server.respondWith [200, {}, JSON.stringify {
         next_page_id: 'abcdef'
         count: 101

--- a/test/mixins/views/sorting-test.coffee
+++ b/test/mixins/views/sorting-test.coffee
@@ -14,6 +14,7 @@ define (require) ->
   class CollectionMock extends Sorted ActiveSyncMachine Chaplin.Collection
     urlRoot: '/test'
     DEFAULTS: _.extend {}, @::DEFAULTS, sort_by: 'attr_a'
+    ignoreKeys: ['bad']
 
   class SortingViewMock extends StringTemplatable \
       Sorting Chaplin.CollectionView
@@ -36,7 +37,7 @@ define (require) ->
         "#{path}?#{utils.querystring.stringify query}"
       collection = new CollectionMock()
       view = new SortingViewMock _.extend {routeName: 'test', collection}
-      collection.fetchWithQuery {}
+      collection.fetchWithQuery {bad: 'something'}
       sandbox.server.respondWith [200, {}, JSON.stringify [{}, {}, {}]]
       sandbox.server.respond()
 


### PR DESCRIPTION
Fix dateFormat view-helper
* Return undefined if input time is not set
* Previously if time was null, it would return “Invalid Date” string

Use better way of accessing query params
* Update Paginating and Sorting mixins to properly access query params
* Add `inclIgnored` param for `queryable.getQuery` method